### PR TITLE
🛠  create by void 

### DIFF
--- a/Sources/SwiftBuilder/CreateByVoid.swift
+++ b/Sources/SwiftBuilder/CreateByVoid.swift
@@ -12,7 +12,7 @@ public protocol CreateByVoid {
 }
 extension Builder: CreateByVoid where Subject: CreateByVoid{
     public init() {
-        subject = .init()
+        subject = Subject()
     }
 }
 

--- a/Tests/SwiftBuilderTests/SwiftBuilderCreateByVoidTests.swift
+++ b/Tests/SwiftBuilderTests/SwiftBuilderCreateByVoidTests.swift
@@ -1,0 +1,20 @@
+//
+//  File.swift
+//  
+//
+//  Created by 游宗諭 on 2020/9/3.
+//
+
+import XCTest
+import SwiftBuilder
+class SwiftBuilderCreateByVoidTests: XCTestCase {
+    struct Target:CreateByVoid {
+        var i = 0
+    }
+    func testBuildByVoid() {
+        let target:Target = Builder()
+        .build()
+        XCTAssertEqual(target.i, 0)
+    }
+}
+


### PR DESCRIPTION
add the ability to indicate generic type by the syntax of `init()`

```swift
struct Target:CreateByVoid { }

let target:Target = 
    Builder()
        .build()

```